### PR TITLE
Update advanced-post-slider.php

### DIFF
--- a/advanced-post-slider.php
+++ b/advanced-post-slider.php
@@ -19,7 +19,7 @@
 		require 'advps-admin.php';
 	}
 	
-	define('advps_url',WP_PLUGIN_URL."/advanced-post-slider/");
+	define('advps_url',plugins_url()."/advanced-post-slider/");
 	
 	require 'advps-db.php';
 	


### PR DESCRIPTION
Had to use plugins_url( ) method. Otherwise your code breaks in HTTPS mode when referencing '.js' files. Because WP_PLUGIN_URL is returning 'http' path instead of 'https'.

http://codex.wordpress.org/Function_Reference/plugins_url
