### PR TITLE
use plugins_url()  instead of WP_PLUGIN_URL

### DIFF
--- a/advanced-post-slider.php
+++ b/advanced-post-slider.php
@@ -19,7 +19,7 @@
 		require 'advps-admin.php';
 	}
 	
-	define('advps_url',WP_PLUGIN_URL."/advanced-post-slider/");
+	define('advps_url',plugins_url()."/advanced-post-slider/");
 	
 	require 'advps-db.php';
 	


### PR DESCRIPTION
Please DON'T use "WP_PLUGIN_URL." because it is not SSL aware. When in the back-end admin panel via HTTPS (all the time if FORCE_SSL_ADMIN is set!). so it does not work...
Instead use: plugins_url().

More info: https://wordpress.org/support/topic/dont-use-wp_plugin_url
